### PR TITLE
fix build on windows

### DIFF
--- a/packages/editor-ui/vite.config.mts
+++ b/packages/editor-ui/vite.config.mts
@@ -11,6 +11,7 @@ import components from 'unplugin-vue-components/vite';
 import browserslistToEsbuild from 'browserslist-to-esbuild';
 import legacy from '@vitejs/plugin-legacy';
 import browserslist from 'browserslist';
+import { posix as pathPosix } from 'path';
 
 const publicPath = process.env.VUE_APP_PUBLIC_PATH || '/';
 
@@ -66,8 +67,11 @@ const plugins = [
 	}),
 	viteStaticCopy({
 		targets: [
-			{ src: resolve('node_modules/web-tree-sitter/tree-sitter.wasm'), dest: '' },
-			{ src: resolve('node_modules/curlconverter/dist/tree-sitter-bash.wasm'), dest: '' },
+			{ src: pathPosix.resolve('node_modules/web-tree-sitter/tree-sitter.wasm'), dest: 'public' },
+			{
+				src: pathPosix.resolve('node_modules/curlconverter/dist/tree-sitter-bash.wasm'),
+				dest: 'public',
+			},
 		],
 	}),
 	vue(),


### PR DESCRIPTION
I kept getting the following error when running 'pnpm build' on windows: n8n-editor-ui:build: error during build:
n8n-editor-ui:build: [vite-plugin-static-copy:build] No file was found to copy on C:\Dev\Kob490\n8n\packages\editor-ui\node_modules\web-tree-sitter\tree-sitter.wasm src.

this change is a fix for that build failure.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
